### PR TITLE
Testing memory leak fix

### DIFF
--- a/System.Data.Async/AssemblyInfo.cs
+++ b/System.Data.Async/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+﻿using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("System.Data.Async.Samples.LocalDb")]

--- a/System.Data.Async/SqlClient/SqlCommandAsync.cs
+++ b/System.Data.Async/SqlClient/SqlCommandAsync.cs
@@ -119,11 +119,17 @@ namespace System.Data.Async.SqlClient
 
         protected override void Dispose(bool disposing)
         {
-            sqlCommand.Dispose();
-            sqlConnectionAsync.Dispose();
+            if (sqlCommand != null)
+            {
+                sqlCommand.Dispose();
+                sqlCommand = null;
+            }
 
-            sqlCommand = null;
-            sqlConnectionAsync = null;
+            if (sqlConnectionAsync != null)
+            {
+                sqlConnectionAsync.Dispose();
+                sqlConnectionAsync = null;
+            }
 
             base.Dispose(disposing);
         }

--- a/System.Data.Async/SqlClient/SqlCommandAsync.cs
+++ b/System.Data.Async/SqlClient/SqlCommandAsync.cs
@@ -121,6 +121,10 @@ namespace System.Data.Async.SqlClient
         {
             sqlCommand.Dispose();
             sqlConnectionAsync.Dispose();
+
+            sqlCommand = null;
+            sqlConnectionAsync = null;
+
             base.Dispose(disposing);
         }
 

--- a/System.Data.Async/SqlClient/SqlCommandAsync.cs
+++ b/System.Data.Async/SqlClient/SqlCommandAsync.cs
@@ -7,8 +7,8 @@ namespace System.Data.Async.SqlClient
     public class SqlCommandAsync : DbCommandAsync
     {
 
-        internal readonly SqlCommand sqlCommand;
-        internal readonly SqlConnectionAsync sqlConnectionAsync;
+        internal SqlCommand sqlCommand;
+        internal SqlConnectionAsync sqlConnectionAsync;
 
         public SqlCommandAsync()
             : this(new SqlCommand(), null)

--- a/System.Data.Async/SqlClient/SqlCommandAsync.cs
+++ b/System.Data.Async/SqlClient/SqlCommandAsync.cs
@@ -7,8 +7,8 @@ namespace System.Data.Async.SqlClient
     public class SqlCommandAsync : DbCommandAsync
     {
 
-        private readonly SqlCommand sqlCommand;
-        private readonly SqlConnectionAsync sqlConnectionAsync;
+        internal readonly SqlCommand sqlCommand;
+        internal readonly SqlConnectionAsync sqlConnectionAsync;
 
         public SqlCommandAsync()
             : this(new SqlCommand(), null)

--- a/System.Data.Async/SqlClient/SqlConnectionAsync.cs
+++ b/System.Data.Async/SqlClient/SqlConnectionAsync.cs
@@ -7,7 +7,7 @@ namespace System.Data.Async.SqlClient
     public class SqlConnectionAsync : DbConnectionAsync
     {
 
-        internal readonly SqlConnection sqlConnection;
+        internal SqlConnection sqlConnection;
 
         public SqlConnectionAsync()
             : this(new SqlConnection())

--- a/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
+++ b/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
@@ -9,8 +9,8 @@ namespace System.Data.Async.SqlClient
     public class SqlDataReaderAsync : DbDataReaderAsync
     {
 
-        internal readonly SqlDataReader sqlDataReader;
-        internal readonly SqlCommandAsync sqlCommandAsync;
+        internal SqlDataReader sqlDataReader;
+        internal SqlCommandAsync sqlCommandAsync;
 
         public SqlDataReaderAsync(SqlDataReader sqlDataReader, SqlCommandAsync sqlCommandAsync)
         {

--- a/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
+++ b/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
@@ -9,8 +9,8 @@ namespace System.Data.Async.SqlClient
     public class SqlDataReaderAsync : DbDataReaderAsync
     {
 
-        private readonly SqlDataReader sqlDataReader;
-        private readonly SqlCommandAsync sqlCommandAsync;
+        internal readonly SqlDataReader sqlDataReader;
+        internal readonly SqlCommandAsync sqlCommandAsync;
 
         public SqlDataReaderAsync(SqlDataReader sqlDataReader, SqlCommandAsync sqlCommandAsync)
         {

--- a/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
+++ b/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
@@ -159,11 +159,17 @@ namespace System.Data.Async.SqlClient
 
         protected override void Dispose(bool disposing)
         {
-            sqlDataReader.Dispose();
-            sqlCommandAsync.Dispose();
+            if (sqlDataReader != null)
+            {
+                sqlDataReader.Dispose();
+                sqlDataReader = null;
+            }
 
-            sqlDataReader = null;
-            sqlCommandAsync = null;
+            if (sqlCommandAsync != null)
+            {
+                sqlCommandAsync.Dispose();
+                sqlCommandAsync = null;
+            }
 
             base.Dispose(disposing);
         }

--- a/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
+++ b/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
@@ -161,6 +161,10 @@ namespace System.Data.Async.SqlClient
         {
             sqlDataReader.Dispose();
             sqlCommandAsync.Dispose();
+
+            sqlDataReader = null;
+            sqlCommandAsync = null;
+
             base.Dispose(disposing);
         }
 


### PR DESCRIPTION
Nullify adapted fields during Dispose() call.

Ref: https://blog.stephencleary.com/2010/02/q-should-i-set-variables-to-null-to.html