### PR TITLE
Upgraded to netstandard2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Implemented override for `IDataReader.GetSchemaTable()`. [#14](https://github.com/adriangodong/system-data-async/pull/14)
+
+### Changed
+
+- Upgraded library target package to netstandard2.0, test platform to netcoreapp2.1, Moq to 4.10.0, MSTest dependencies to 15.9.0 and 1.4.0. [#14](https://github.com/adriangodong/system-data-async/pull/14)
+
+## [1.0.6] - 2017-12-20
+
+### Changed
+
+- Upgraded System.Data.SqlClient to 4.4.2. [#13](https://github.com/adriangodong/system-data-async/pull/13)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 This library adds interfaces and adapters to allow working with async methods available in System.Data abstract classes but not interfaces.
 
-Sample migration:
+## Sample migration
 
 ```diff
 - // With System.Data.Common
@@ -22,3 +22,5 @@ public void GetCommand()
     CreateCommand(connection);
 }
 ```
+
+## [Changelog](CHANGELOG.md)

--- a/Samples/LocalDb/LocalDb.csproj
+++ b/Samples/LocalDb/LocalDb.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>System.Data.Async.Samples.LocalDb</AssemblyName>
     <PackageId>System.Data.Async.Samples.LocalDb</PackageId>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 
@@ -17,7 +17,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
-    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/LocalDb/LocalDb.csproj
+++ b/Samples/LocalDb/LocalDb.csproj
@@ -14,10 +14,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Samples/Moq/Moq.csproj
+++ b/Samples/Moq/Moq.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>System.Data.Async.Samples.Moq</AssemblyName>
     <PackageId>System.Data.Async.Samples.Moq</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.1.1</RuntimeFrameworkVersion>
     <IsPackable>False</IsPackable>
   </PropertyGroup>
 

--- a/Samples/Moq/Moq.csproj
+++ b/Samples/Moq/Moq.csproj
@@ -16,10 +16,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.1.18" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.1.18" />
-    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
+++ b/System.Data.Async/SqlClient/SqlDataReaderAsync.cs
@@ -123,6 +123,11 @@ namespace System.Data.Async.SqlClient
             return sqlDataReader.IsDBNull(ordinal);
         }
 
+        public override DataTable GetSchemaTable()
+        {
+            return sqlDataReader.GetSchemaTable();
+        }
+
         public override int FieldCount => sqlDataReader.FieldCount;
 
         public override object this[int ordinal] => sqlDataReader[ordinal];

--- a/System.Data.Async/System.Data.Async.csproj
+++ b/System.Data.Async/System.Data.Async.csproj
@@ -19,7 +19,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
   </ItemGroup>
 
 </Project>

--- a/System.Data.Async/System.Data.Async.csproj
+++ b/System.Data.Async/System.Data.Async.csproj
@@ -15,7 +15,6 @@
     <IncludeSymbols>True</IncludeSymbols>
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <Version>0.0.0</Version>
-    <PackageVersion>0.0.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/System.Data.Async/System.Data.Async.csproj
+++ b/System.Data.Async/System.Data.Async.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.3;net47</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net47</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,18 +2,28 @@ image: Visual Studio 2017
 configuration: Release
 version: '{build}'
 
+install:
+- ps: >-
+    if ($env:APPVEYOR_REPO_TAG -eq "false")
+    {
+      $env:COMMIT_DESCRIPTION = git describe --tags
+    }
+    else
+    {
+      $env:COMMIT_DESCRIPTION = $env:APPVEYOR_REPO_TAG_NAME
+    }
+    Write-Host Build version is $env:COMMIT_DESCRIPTION
+
 dotnet_csproj:
   patch: true
   file: 'System.Data.Async\System.Data.Async.csproj'
-  version: $(appveyor_repo_tag_name)
-  package_version: $(appveyor_repo_tag_name)
+  version: $(commit_description)
 
 before_build:
 - cmd: dotnet restore
 
 build:
   project: System.Data.Async.sln
-  verbosity: minimal
 
 test_script:
 - cmd: >-


### PR DESCRIPTION
Upgraded library to target netstandard2.0.

The end goal is to allow calling `GetSchemaTable`.

This PR also includes appveyor.yaml update to allow publishing prerelease packages to `https://ci.appveyor.com/nuget/system-data-async`.