### PR TITLE
Modify build to generate prerelease semver.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Previously, we append prerelease segment to the closest release version when building prerelease commits. We now increment the closest release version patch segment before appending the prerelease segment. [#15](https://github.com/adriangodong/system-data-async/pull/15)
 - Upgraded library target package to netstandard2.0, test platform to netcoreapp2.1, Moq to 4.10.0, MSTest dependencies to 15.9.0 and 1.4.0. [#14](https://github.com/adriangodong/system-data-async/pull/14)
 
 ## [1.0.6] - 2017-12-20

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,12 @@ install:
 - ps: >-
     if ($env:APPVEYOR_REPO_TAG -eq "false")
     {
-      $env:COMMIT_DESCRIPTION = git describe --tags
+      $version = & { git describe --tags } 2>&1
+      $baseVersion = (& { git describe --tags --abbrev=0 }) 2>&1
+      $prereleaseVersion = $version.SubString($baseVersion.Length)
+      $adjustedBaseVersion = $baseVersion.Split(".")
+      $adjustedBaseVersion[2] = ($adjustedBaseVersion[2] / 1) + 1
+      $env:COMMIT_DESCRIPTION = [System.String]::Join(".", $adjustedBaseVersion) + $prereleaseVersion
     }
     else
     {


### PR DESCRIPTION
Previously, we use some sort of post-release versioning with pre-release schema. For example, #14 builds as `1.0.6-xxx` even though `1.0.6` has been released. This PR modifies the build script to generate a pre-release version instead (`1.0.7-xxx`).